### PR TITLE
Bump UUID to support 10.11.2

### DIFF
--- a/BindDeleteKeyToArchive/BindDeleteKeyToArchive-Info.plist
+++ b/BindDeleteKeyToArchive/BindDeleteKeyToArchive-Info.plist
@@ -24,6 +24,7 @@
 	<string>Copyright © 2013 Ben Lenarts. All rights reserved.</string>
 	<key>SupportedPluginCompatibilityUUIDs</key>
 	<array>
+		<string>1550C683-EA48-4036-B7CE-FB6F5D13EE02</string>
 		<string>608CE00F-4576-4CAD-B362-F3CCB7DE8D67</string>
 		<string>1146A009-E373-4DB6-AB4D-47E59A7E50FD</string>
 		<string>2183B2CD-BEDF-4AA6-AC18-A1BBED2E3354</string>

--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ This mail bundle binds the delete key to the "archive messages" command in the l
 
 If you prefer to put emails in the archive by default, this extension makes it easier to go through your inbox using the keyboard.
 
-## Download build
+## Add current Mail.app UUID to Info.plist
 
-http://benlenarts.github.com/BindDeleteKeyToArchive.zip
+1. Obtain the latest UUID:
+
+       `defaults read /Applications/Mail.app/Contents/Info PluginCompatibilityUUID | pbcopy`
+
+2. Add that UUID to the 'SupportedPluginCompatibilityUUIDs' key in
+   Info.plist
 
 ## Build instructions
 
-1. Build with Xcode 4.6.1
+1. Build with Xcode 4.6.1 (or higher)
 2. Place resulting .mailbundle in ~/Library/Mail/Bundles
 3. Enable bundle support in Mail:
 


### PR DESCRIPTION
I added the UUID for 10.11.2 to the Info.plist and added some info in the Readme on obtaining new UUIDs in the future.
